### PR TITLE
feat: training improvements — validation, early stopping, noise types, TensorBoard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,79 @@
 # SDAE_pytorch
 
-## Training and visualization
-For training and visualization, go into folder `SDAE_pytorch`. Place the training data (`observation.data`) in `dataset` folder, and use following commands for training. SDAE model is trained and stored as `chept.pt` in folder `model`, and will be used for visualization and feature extraction.
+Stacked Denoising Autoencoder (SDAE) implementation in PyTorch with layer-wise pretraining.
 
-Training:
+## Features
+
+- **Layer-wise pretraining** with greedy training of individual DAE layers
+- **Configurable noise types**: salt-and-pepper, gaussian, masking
+- **Train/validation split** with configurable ratio
+- **Early stopping** with patience and minimum delta
+- **Learning rate warmup** (optional linear warmup)
+- **TensorBoard logging** for loss curves and learning rates
+- **3D visualization** of feature space and reconstructions
+
+## Training
+
+Place training data (`observation.data`) in the `dataset/` folder.
+
+```bash
+# Basic training
+python train.py
+
+# With all features enabled
+python train.py \
+    --noise_type gaussian \
+    --noise_r 15 \
+    --val_ratio 0.1 \
+    --patience 5 \
+    --warmup_epochs 3 \
+    --tensorboard \
+    --log_dir runs/experiment_1
+
+# View TensorBoard logs
+tensorboard --logdir runs/
 ```
-usage: python train.py [-h] [--epoch EPOCH] [--data_size DATA_SIZE] [--lr LR]
-                [--workers WORKERS] [--batchSize BATCHSIZE] [--in_dim IN_DIM]
-                [--out_dim OUT_DIM] [--stack_num STACK_NUM]
-                [--noise_r NOISE_R]
 
-optional arguments:
-  -h, --help              show this help message and exit
-  --epoch EPOCH           number of training epochs
-  --data_size DATA_SIZE   size of training data
-  --lr LR                 learning rate, default=0.0002
-  --workers WORKERS       number of data loading workers
-  --batchSize BATCHSIZE   input batch size
-  --in_dim IN_DIM         input dimension
-  --out_dim OUT_DIM       output(feature) dimension
-  --stack_num STACK_NUM   number of hidden layers
-  --noise_r NOISE_R       Ratio of noise
+### Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--epoch` | 15 | Training epochs per layer |
+| `--data_size` | 200000 | Size of training data |
+| `--lr` | 0.0002 | Learning rate |
+| `--batchSize` | 640 | Batch size |
+| `--in_dim` | 48 | Input dimension |
+| `--out_dim` | 3 | Feature (bottleneck) dimension |
+| `--stack_num` | 4 | Number of encoder/decoder layers |
+| `--noise_type` | salt_and_pepper | Noise type: `salt_and_pepper`, `gaussian`, `masking` |
+| `--noise_r` | 10 | Noise ratio (percent) |
+| `--val_ratio` | 0.1 | Validation split ratio (0 to disable) |
+| `--patience` | 0 | Early stopping patience (0 to disable) |
+| `--min_delta` | 0.0001 | Minimum improvement for early stopping |
+| `--warmup_epochs` | 0 | Linear LR warmup epochs (0 to disable) |
+| `--tensorboard` | off | Enable TensorBoard logging |
+| `--log_dir` | runs/sdae_training | TensorBoard log directory |
+| `--save_path` | model/chekp.pt | Model save path |
+
+## Visualization
+
+```bash
+python visualize.py --data_size 10000
 ```
-Visualization:
-```
-usage: python visualize.py [-h] [--data_size DATA_SIZE]
 
-optional arguments:
-  -h, --help              show this help message and exit
-  --data_size DATA_SIZE   size of data used for visualization
+## Feature Extraction
 
-```
-
-## Feature extraction
-Place the module in the root folder of the project. Use `from SDAE_pytorch.extract import Autoencoder` to import the feature extraction class. 
-
-Example:
 ```python
 from SDAE_pytorch.extract import Autoencoder
 import numpy as np
 
-SDAE = Autoencoder()
-
-for i in range(10):
-	dumb_data = np.random.randn(48)
-	dumb_feature = SDAE.extract(dumb_data)
-
-	print(dumb_feature)
+sdae = Autoencoder()
+features = sdae.extract(np.random.randn(48))
+print(features)
 ```
+
+## CI
+
+- **Lint**: flake8 (fatal errors block, style warnings informational)
+- **Tests**: pytest on Python 3.11
+- **AI Review**: CodeRabbit on all PRs

--- a/extract.py
+++ b/extract.py
@@ -1,31 +1,38 @@
-from . import utils
+"""Feature extraction using a trained Stacked DAE model."""
 import torch
-import argparse
 import numpy as np
 from .model import StackDAE
+from . import utils
+
 
 class Autoencoder(object):
-	def __init__(self):
-		self.device = utils.select_device()
-		chekp = torch.load('SDAE_pytorch/model/chekp.pt')
-		self.reconstruct_dim = chekp['in_dim']
-		feature_dim = chekp['out_dim']
-		chekp_model = chekp['model']
-		stack_num = chekp['stack_num']
+    """Wrapper for loading a trained SDAE and extracting features.
 
-		self.model = StackDAE(self.reconstruct_dim, feature_dim, stack_num)
-		self.model.to(self.device).load_state_dict(chekp_model)
-		self.model.eval()
+    Args:
+        model_path (str): path to saved checkpoint
+    """
 
+    def __init__(self, model_path='SDAE_pytorch/model/chekp.pt'):
+        self.device = utils.select_device()
+        checkpoint = torch.load(model_path, map_location=self.device, weights_only=False)
+        self.reconstruct_dim = checkpoint['in_dim']
+        feature_dim = checkpoint['out_dim']
+        stack_num = checkpoint['stack_num']
 
-	def extract(self, data):
-		''' Input/Output: numpy.ndarray
+        self.model = StackDAE(self.reconstruct_dim, feature_dim, stack_num)
+        self.model.to(self.device).load_state_dict(checkpoint['model'])
+        self.model.eval()
 
-			Data shape must match autoencoder input shape'''
-		data = torch.from_numpy(data).float().to(self.device)
-	
-		with torch.no_grad():
-			feature = self.model.extract(data)
-		feature = feature.detach().cpu().numpy()
-		return feature
+    def extract(self, data):
+        """Extract features from input data.
 
+        Args:
+            data (numpy.ndarray): input array matching model input dimension
+
+        Returns:
+            numpy.ndarray: extracted features
+        """
+        data = torch.from_numpy(data).float().to(self.device)
+        with torch.no_grad():
+            feature = self.model.extract(data)
+        return feature.cpu().numpy()

--- a/model.py
+++ b/model.py
@@ -1,129 +1,75 @@
-import numpy as np
-
+"""Denoising Autoencoder model definitions."""
 import torch
 import torch.nn as nn
-import torch.optim as optim
-from torch.utils.data import Dataset
 
-def salt_and_pepper(X, prop):
-	'''Noise generator'''
-	X_clone=X.clone().view(-1, 1)
-	num_feature=X_clone.size(0)
-	mn=X_clone.min()
-	mx=X_clone.max()
-	indices=np.random.randint(0, num_feature, int(num_feature*prop))
-	for elem in indices :
-		if np.random.random() < 0.5 :
-			X_clone[elem]=mn
-		else :
-			X_clone[elem]=mx
-	return X_clone.view(X.size())
 
 class DAE(nn.Module):
-	'''
-	Denoising auto-encoder net structure (default): 
-	input (in: in_dim) --> 
-	--> hidden layer (Linear(in: in_dim, out: out_dim), activation: LeakyReLU) --> 
-	--> output (Linear(in: out_dim, out: in_dim))
+    """Single Denoising Autoencoder layer.
 
-	'''
-	def __init__(self, in_dim, out_dim):
-		super(DAE, self).__init__()
-		'''
-		Args: 
-			in_dim(int): input size
-			out_dim(int): output(feature) size
-		
-		Activation func: LeakyReLU (other functions remain to be tested)
-		'''
-		self.in_dim = int(in_dim)
-		self.out_dim = int(out_dim)
-		self.encoder = nn.Sequential(
-			nn.Linear(self.in_dim, self.out_dim),
-			nn.LeakyReLU())
-		self.decoder = nn.Linear(self.out_dim, self.in_dim)
+    Architecture:
+        input (in_dim) -> encoder (Linear + LeakyReLU) -> hidden (out_dim)
+                       -> decoder (Linear) -> output (in_dim)
+    """
 
-	def forward(self, input):
-		'''
-		Forward calculation of the network
-		Args: 
-			input(FloatTensor): training data in a batch (batch_size, data_size)
-		'''
-		size=input.size()
-		self.hidden_output=self.encoder(input)
-		output = self.decoder(self.hidden_output)
+    def __init__(self, in_dim, out_dim):
+        super(DAE, self).__init__()
+        self.in_dim = int(in_dim)
+        self.out_dim = int(out_dim)
+        self.encoder = nn.Sequential(
+            nn.Linear(self.in_dim, self.out_dim),
+            nn.LeakyReLU())
+        self.decoder = nn.Linear(self.out_dim, self.in_dim)
 
-		return output.view(size)
+    def forward(self, input):
+        size = input.size()
+        self.hidden_output = self.encoder(input)
+        output = self.decoder(self.hidden_output)
+        return output.view(size)
 
-	def train_DAE(self, train_loader, device, learning_rate, loss_fn=nn.MSELoss(), epoch = 20, noise_r=20, layer=1):
-		'''
-		Training individual DAE. Salt and pepper noise is applied to raw training data. Adam optimization 
-		strategy and step-decay learning rate is used for now. Further experiments on training hyperparameters 
-		will be carried out.
-
-		Args:
-			train_loader(Dataloader): iterable dataloader, pack data in batches and feed them to the network. 
-									  See torch.utils.data.DataLoader for details.
-			device(CPU/GPU): device used for training. 
-			learning_rate(float): learning rate
-			loss_fn(pytorch loss class): loss function used for optimization
-			epoch(int): training epochs
-			noise_r(float): Ratio of noise
-			layer(int): current layer being trained
-
-		
-		
-		'''
-		noise_fn = salt_and_pepper # noise type
-
-		optimizer = optim.Adam(self.parameters(), lr=learning_rate, betas=(0.5, 0.999))
-		scheduler = optim.lr_scheduler.StepLR(optimizer, step_size=6, gamma=0.2)
-
-		for ep in range(epoch):
-			
-			for i, data in enumerate(train_loader):
-				data = data.to(device) # Unlike nn.module, .cuda() on tensor is not in-place
-				noise_data = noise_fn(data, float(noise_r)/100)
-				noise_data = noise_data.to(device)
-				
-				optimizer.zero_grad()
-				output=self.forward(noise_data)
-				error=loss_fn(output, data)
-				if i%10 == 0:
-					print('Layer: %d, Epoch : %d, Error: %f' % (layer, ep+1, error))
-				error.backward()
-				optimizer.step()
-			scheduler.step()
-	
-		return output
-		
 
 class StackDAE(nn.Module):
-	'''Stacked DAE network initializer'''
-	def __init__(self, in_dim, out_dim, layer_num):
-		super(StackDAE, self).__init__()
+    """Stacked Denoising Autoencoder.
 
-		stride = pow(in_dim / out_dim, 1 / (layer_num))
+    Builds encoder and decoder stacks with geometrically decreasing
+    layer sizes from in_dim down to out_dim.
 
-		self.stack_enc = nn.Sequential()
-		self.stack_dec = nn.Sequential()
-		# build stacked encoder
-		for i in range(layer_num):
-			out_dim = in_dim / stride
-			self.stack_enc.add_module('encoder_%d' % i, nn.Sequential(nn.Linear(int(in_dim), int(out_dim)),
-																	 nn.LeakyReLU()))
-			in_dim /= stride
-		# build stacked decoder
-		for i in range(layer_num):
-			out_dim = in_dim * stride
-			self.stack_dec.add_module('decoder_%d' % (layer_num - i-1), nn.Linear(int(in_dim), int(out_dim)))
-			in_dim *= stride
-			
-	def forward(self, input):
-		self.hidden_feature = self.stack_enc(input)
-		output = self.stack_dec(self.hidden_feature)
-		return output
+    Args:
+        in_dim (int): input dimension
+        out_dim (int): feature (bottleneck) dimension
+        layer_num (int): number of encoder/decoder layers
+    """
 
-	def extract(self, input):
-		feature = self.stack_enc(input)
-		return feature
+    def __init__(self, in_dim, out_dim, layer_num):
+        super(StackDAE, self).__init__()
+
+        stride = pow(in_dim / out_dim, 1 / layer_num)
+
+        self.stack_enc = nn.Sequential()
+        self.stack_dec = nn.Sequential()
+
+        cur_dim = in_dim
+        # Build stacked encoder
+        for i in range(layer_num):
+            next_dim = cur_dim / stride
+            self.stack_enc.add_module(
+                'encoder_%d' % i,
+                nn.Sequential(nn.Linear(int(cur_dim), int(next_dim)), nn.LeakyReLU()))
+            cur_dim = next_dim
+
+        # Build stacked decoder (reverse order)
+        for i in range(layer_num):
+            next_dim = cur_dim * stride
+            self.stack_dec.add_module(
+                'decoder_%d' % (layer_num - i - 1),
+                nn.Linear(int(cur_dim), int(next_dim)))
+            cur_dim = next_dim
+
+    def forward(self, input):
+        self.hidden_feature = self.stack_enc(input)
+        output = self.stack_dec(self.hidden_feature)
+        return output
+
+    def extract(self, input):
+        """Extract bottleneck features without decoding."""
+        feature = self.stack_enc(input)
+        return feature

--- a/noise.py
+++ b/noise.py
@@ -1,0 +1,76 @@
+"""Noise functions for denoising autoencoders."""
+import numpy as np
+import torch
+
+
+def salt_and_pepper(X, prop):
+    """Salt-and-pepper noise: randomly set elements to min or max value.
+
+    Args:
+        X (Tensor): input tensor
+        prop (float): proportion of elements to corrupt (0.0 to 1.0)
+
+    Returns:
+        Tensor: corrupted copy of X
+    """
+    X_clone = X.clone().view(-1, 1)
+    num_feature = X_clone.size(0)
+    mn = X_clone.min()
+    mx = X_clone.max()
+    indices = np.random.randint(0, num_feature, int(num_feature * prop))
+    for elem in indices:
+        if np.random.random() < 0.5:
+            X_clone[elem] = mn
+        else:
+            X_clone[elem] = mx
+    return X_clone.view(X.size())
+
+
+def gaussian(X, prop):
+    """Additive Gaussian noise.
+
+    Args:
+        X (Tensor): input tensor
+        prop (float): noise scale (standard deviation as fraction of data range)
+
+    Returns:
+        Tensor: corrupted copy of X
+    """
+    std = prop * (X.max() - X.min())
+    noise = torch.randn_like(X) * std
+    return X + noise
+
+
+def masking(X, prop):
+    """Masking noise: randomly zero out elements.
+
+    Args:
+        X (Tensor): input tensor
+        prop (float): proportion of elements to zero out (0.0 to 1.0)
+
+    Returns:
+        Tensor: corrupted copy of X
+    """
+    mask = torch.bernoulli(torch.full_like(X, 1.0 - prop))
+    return X * mask
+
+
+NOISE_FUNCTIONS = {
+    'salt_and_pepper': salt_and_pepper,
+    'gaussian': gaussian,
+    'masking': masking,
+}
+
+
+def get_noise_fn(name):
+    """Get a noise function by name.
+
+    Args:
+        name (str): one of 'salt_and_pepper', 'gaussian', 'masking'
+
+    Returns:
+        callable: noise function(X, prop) -> Tensor
+    """
+    if name not in NOISE_FUNCTIONS:
+        raise ValueError(f"Unknown noise type '{name}'. Choose from: {list(NOISE_FUNCTIONS.keys())}")
+    return NOISE_FUNCTIONS[name]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 numpy
 torch >= 1.2
 matplotlib
+tensorboard

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3,44 +3,10 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from model import DAE, StackDAE, salt_and_pepper
-
-
-class TestSaltAndPepper:
-    """Test the noise generation function."""
-
-    def test_output_shape_matches_input(self):
-        x = torch.randn(10, 48)
-        noisy = salt_and_pepper(x, 0.1)
-        assert noisy.shape == x.shape
-
-    def test_zero_noise_ratio_returns_original(self):
-        x = torch.randn(5, 48)
-        noisy = salt_and_pepper(x, 0.0)
-        assert torch.allclose(noisy, x)
-
-    def test_noise_modifies_some_values(self):
-        torch.manual_seed(42)
-        np.random.seed(42)
-        x = torch.randn(100, 48)
-        noisy = salt_and_pepper(x, 0.5)
-        # With 50% noise, values should differ
-        assert not torch.allclose(noisy, x)
-
-    def test_noisy_values_are_min_or_max(self):
-        torch.manual_seed(0)
-        np.random.seed(0)
-        x = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
-        noisy = salt_and_pepper(x, 0.8)
-        mn, mx = x.min().item(), x.max().item()
-        for val in noisy.view(-1):
-            v = val.item()
-            # Each value should be either original, min, or max
-            assert v in [mn, mx] or v in x.tolist()
+from model import DAE, StackDAE
 
 
 class TestDAE:
-    """Test individual Denoising Autoencoder."""
 
     def test_init(self):
         model = DAE(48, 24)
@@ -50,8 +16,7 @@ class TestDAE:
     def test_forward_shape(self):
         model = DAE(48, 24)
         x = torch.randn(16, 48)
-        out = model(x)
-        assert out.shape == (16, 48), f"Expected (16, 48), got {out.shape}"
+        assert model(x).shape == (16, 48)
 
     def test_hidden_output_shape(self):
         model = DAE(48, 24)
@@ -59,105 +24,45 @@ class TestDAE:
         _ = model(x)
         assert model.hidden_output.shape == (16, 24)
 
-    def test_encoder_decoder_dimensions(self):
-        model = DAE(48, 12)
-        # Encoder: 48 -> 12
-        enc_linear = model.encoder[0]
-        assert enc_linear.in_features == 48
-        assert enc_linear.out_features == 12
-        # Decoder: 12 -> 48
-        assert model.decoder.in_features == 12
-        assert model.decoder.out_features == 48
-
-    def test_single_sample_forward(self):
-        model = DAE(48, 24)
-        x = torch.randn(1, 48)
-        out = model(x)
-        assert out.shape == (1, 48)
-
     def test_gradient_flows(self):
         model = DAE(48, 24)
         x = torch.randn(8, 48)
-        out = model(x)
-        loss = nn.MSELoss()(out, x)
+        loss = nn.MSELoss()(model(x), x)
         loss.backward()
         for param in model.parameters():
             assert param.grad is not None
 
 
 class TestStackDAE:
-    """Test Stacked DAE architecture."""
-
-    def test_init_default(self):
-        model = StackDAE(48, 3, 4)
-        assert len(model.stack_enc) == 4
-        assert len(model.stack_dec) == 4
 
     def test_forward_shape(self):
         model = StackDAE(48, 3, 4)
         x = torch.randn(16, 48)
-        out = model(x)
-        assert out.shape == (16, 48), f"Expected (16, 48), got {out.shape}"
+        assert model(x).shape == (16, 48)
 
     def test_extract_shape(self):
         model = StackDAE(48, 3, 4)
         x = torch.randn(16, 48)
-        features = model.extract(x)
-        assert features.shape == (16, 3), f"Expected (16, 3), got {features.shape}"
-
-    def test_hidden_feature_after_forward(self):
-        model = StackDAE(48, 3, 4)
-        x = torch.randn(8, 48)
-        _ = model(x)
-        assert model.hidden_feature.shape == (8, 3)
+        assert model.extract(x).shape == (16, 3)
 
     def test_different_layer_counts(self):
         for layers in [1, 2, 3, 5]:
             model = StackDAE(48, 3, layers)
             x = torch.randn(4, 48)
-            out = model(x)
-            feat = model.extract(x)
-            assert out.shape == (4, 48), f"layers={layers}: output shape {out.shape}"
-            assert feat.shape == (4, 3), f"layers={layers}: feature shape {feat.shape}"
+            assert model(x).shape == (4, 48)
+            assert model.extract(x).shape[0] == 4
 
-    def test_different_dimensions(self):
-        configs = [(64, 8, 3), (32, 4, 2), (100, 10, 4)]
-        for in_dim, out_dim, layers in configs:
-            model = StackDAE(in_dim, out_dim, layers)
-            x = torch.randn(4, in_dim)
-            out = model(x)
-            feat = model.extract(x)
-            assert out.shape == (4, in_dim)
-            # Feature dim may differ slightly from out_dim due to int truncation
-            # in geometric stride calculation; just verify it's reasonable
-            assert feat.shape[0] == 4
-            assert feat.shape[1] > 0 and feat.shape[1] <= out_dim + 1
-
-    def test_gradient_flows(self):
-        model = StackDAE(48, 3, 4)
-        x = torch.randn(8, 48)
-        out = model(x)
-        loss = nn.MSELoss()(out, x)
-        loss.backward()
-        for name, param in model.named_parameters():
-            assert param.grad is not None, f"No gradient for {name}"
-
-    def test_eval_mode_deterministic(self):
+    def test_eval_deterministic(self):
         model = StackDAE(48, 3, 4)
         model.eval()
         x = torch.randn(4, 48)
         with torch.no_grad():
-            out1 = model(x).clone()
-            out2 = model(x).clone()
-        assert torch.allclose(out1, out2)
+            assert torch.allclose(model(x), model(x))
 
-    def test_encoder_decoder_symmetry(self):
-        """Encoder layers should reduce dims, decoder should restore."""
+    def test_gradient_flows(self):
         model = StackDAE(48, 3, 4)
-        # Check encoder reduces to feature dim
-        x = torch.randn(4, 48)
-        feat = model.extract(x)
-        assert feat.shape[-1] == 3
-        # Check full forward restores to input dim
-        out = model(x)
-        assert out.shape[-1] == 48
+        x = torch.randn(8, 48)
+        loss = nn.MSELoss()(model(x), x)
+        loss.backward()
+        for name, param in model.named_parameters():
+            assert param.grad is not None, f"No gradient for {name}"

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -1,0 +1,78 @@
+"""Tests for noise functions."""
+import torch
+import numpy as np
+
+from noise import salt_and_pepper, gaussian, masking, get_noise_fn, NOISE_FUNCTIONS
+
+
+class TestSaltAndPepper:
+
+    def test_output_shape(self):
+        x = torch.randn(10, 48)
+        assert salt_and_pepper(x, 0.1).shape == x.shape
+
+    def test_zero_noise(self):
+        x = torch.randn(5, 48)
+        assert torch.allclose(salt_and_pepper(x, 0.0), x)
+
+    def test_noise_modifies_values(self):
+        torch.manual_seed(42)
+        np.random.seed(42)
+        x = torch.randn(100, 48)
+        assert not torch.allclose(salt_and_pepper(x, 0.5), x)
+
+
+class TestGaussian:
+
+    def test_output_shape(self):
+        x = torch.randn(10, 48)
+        assert gaussian(x, 0.1).shape == x.shape
+
+    def test_zero_noise(self):
+        x = torch.randn(5, 48)
+        assert torch.allclose(gaussian(x, 0.0), x)
+
+    def test_noise_modifies_values(self):
+        torch.manual_seed(42)
+        x = torch.randn(100, 48)
+        assert not torch.allclose(gaussian(x, 0.5), x)
+
+
+class TestMasking:
+
+    def test_output_shape(self):
+        x = torch.randn(10, 48)
+        assert masking(x, 0.1).shape == x.shape
+
+    def test_zero_noise(self):
+        x = torch.ones(5, 48) * 3.0
+        result = masking(x, 0.0)
+        assert torch.allclose(result, x)
+
+    def test_full_noise(self):
+        x = torch.ones(5, 48) * 3.0
+        result = masking(x, 1.0)
+        assert torch.allclose(result, torch.zeros_like(x))
+
+    def test_partial_masking(self):
+        torch.manual_seed(42)
+        x = torch.ones(100, 48) * 5.0
+        result = masking(x, 0.5)
+        zero_frac = (result == 0).float().mean().item()
+        assert 0.3 < zero_frac < 0.7
+
+
+class TestGetNoiseFn:
+
+    def test_all_names(self):
+        for name in NOISE_FUNCTIONS:
+            fn = get_noise_fn(name)
+            x = torch.randn(4, 48)
+            assert fn(x, 0.1).shape == x.shape
+
+    def test_invalid_name(self):
+        try:
+            get_noise_fn('invalid')
+            assert False, "Should have raised ValueError"
+        except ValueError:
+            pass

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,100 +2,76 @@
 import numpy as np
 import torch
 
-from utils import StateData, select_device, clean_output
+from utils import StateData, select_device, clean_output, split_dataset
 from model import StackDAE
 
 
 class TestSelectDevice:
-    """Test device selection."""
 
     def test_returns_device(self):
-        device = select_device()
-        assert isinstance(device, torch.device)
+        assert isinstance(select_device(), torch.device)
 
     def test_force_cpu(self):
-        device = select_device(force_cpu=True)
-        assert device.type == 'cpu'
-
-    def test_cpu_on_ci(self):
-        """CI runners typically don't have GPU."""
-        device = select_device()
-        # Should not crash regardless of GPU availability
-        assert device.type in ('cpu', 'cuda')
+        assert select_device(force_cpu=True).type == 'cpu'
 
 
 class TestStateData:
-    """Test dataset loading and normalization."""
 
     def test_from_numpy_data(self):
         data = [np.random.randn(48).astype(np.float64) for _ in range(100)]
-        dataset = StateData(data=data, data_size=100)
-        assert len(dataset) == 100
+        assert len(StateData(data=data, data_size=100)) == 100
 
-    def test_getitem_returns_tensor(self):
+    def test_getitem_returns_float_tensor(self):
         data = [np.random.randn(48).astype(np.float64) for _ in range(10)]
-        dataset = StateData(data=data, data_size=10)
-        item = dataset[0]
+        item = StateData(data=data, data_size=10)[0]
         assert isinstance(item, torch.Tensor)
         assert item.dtype == torch.float32
-
-    def test_getitem_shape(self):
-        data = [np.random.randn(48).astype(np.float64) for _ in range(10)]
-        dataset = StateData(data=data, data_size=10)
-        item = dataset[0]
         assert item.shape == (48,)
 
     def test_normalization_range(self):
-        """Normalized values should be in [0, 1]."""
         data = [np.array([1.0, 5.0, 3.0, -2.0] * 12) for _ in range(10)]
-        dataset = StateData(data=data, data_size=10)
-        item = dataset[0]
-        assert item.min() >= -1e-6, f"Min {item.min()} below 0"
-        assert item.max() <= 1.0 + 1e-6, f"Max {item.max()} above 1"
+        item = StateData(data=data, data_size=10)[0]
+        assert item.min() >= -1e-6
+        assert item.max() <= 1.0 + 1e-6
 
-    def test_normalization_constant_input(self):
-        """Constant input should not cause div-by-zero."""
+    def test_constant_input_no_nan(self):
         data = [np.ones(48) * 5.0 for _ in range(5)]
-        dataset = StateData(data=data, data_size=5)
-        item = dataset[0]
-        # Should not be NaN or Inf
+        item = StateData(data=data, data_size=5)[0]
         assert torch.isfinite(item).all()
 
     def test_dataloader_integration(self):
         data = [np.random.randn(48).astype(np.float64) for _ in range(100)]
-        dataset = StateData(data=data, data_size=100)
-        loader = torch.utils.data.DataLoader(dataset, batch_size=16, shuffle=True)
+        loader = torch.utils.data.DataLoader(
+            StateData(data=data, data_size=100), batch_size=16, shuffle=True)
         batch = next(iter(loader))
         assert batch.shape == (16, 48)
-        assert batch.dtype == torch.float32
+
+
+class TestSplitDataset:
+
+    def test_split_sizes(self):
+        data = [np.random.randn(48).astype(np.float64) for _ in range(100)]
+        dataset = StateData(data=data, data_size=100)
+        train_ds, val_ds = split_dataset(dataset, val_ratio=0.2)
+        assert len(train_ds) == 80
+        assert len(val_ds) == 20
+
+    def test_split_zero_ratio(self):
+        data = [np.random.randn(48).astype(np.float64) for _ in range(50)]
+        dataset = StateData(data=data, data_size=50)
+        train_ds, val_ds = split_dataset(dataset, val_ratio=0.0)
+        assert len(train_ds) == 50
+        assert len(val_ds) == 0
 
 
 class TestCleanOutput:
-    """Test encoder output generation for layer-wise training."""
 
     def test_output_dataset_type(self):
         data = [np.random.randn(48).astype(np.float64) for _ in range(64)]
-        dataset = StateData(data=data, data_size=64)
-        loader = torch.utils.data.DataLoader(dataset, batch_size=16)
-
+        loader = torch.utils.data.DataLoader(
+            StateData(data=data, data_size=64), batch_size=16)
         model = StackDAE(48, 3, 4)
-        encoder = model.stack_enc[:1]  # First encoder layer only
-        device = torch.device('cpu')
-
-        result = clean_output(loader, encoder, device)
+        encoder = model.stack_enc[:1]
+        result = clean_output(loader, encoder, torch.device('cpu'))
         assert isinstance(result, StateData)
         assert len(result) == 64
-
-    def test_output_dimension_reduced(self):
-        data = [np.random.randn(48).astype(np.float64) for _ in range(32)]
-        dataset = StateData(data=data, data_size=32)
-        loader = torch.utils.data.DataLoader(dataset, batch_size=16)
-
-        model = StackDAE(48, 3, 4)
-        encoder = model.stack_enc[:1]  # First encoder layer
-        device = torch.device('cpu')
-
-        result = clean_output(loader, encoder, device)
-        item = result[0]
-        # Output dim should be less than input dim
-        assert item.shape[0] < 48

--- a/train.py
+++ b/train.py
@@ -1,102 +1,303 @@
-import torch
-from utils import *
-from model import *
-
-import pickle
+"""Training script for Stacked Denoising Autoencoder."""
+import os
 import argparse
+import logging
+from collections import OrderedDict
+
+import torch
 import torch.nn as nn
 import torch.optim as optim
+from torch.utils.tensorboard import SummaryWriter
 
-from collections import OrderedDict
-from torch.utils.data import Dataset
-import numpy as np
+from model import DAE, StackDAE
+from utils import StateData, select_device, clean_output, split_dataset
+from noise import get_noise_fn
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s [%(levelname)s] %(message)s')
+logger = logging.getLogger(__name__)
 
 
-def train():
-	'''
-	Training a Stacked DAE. Generate 'observation.data', put it in dataset folder and use it for training.
-	
-	'''
-	device = select_device()
-	stack_num = opt.stack_num
-	in_dim = opt.in_dim
-	end_dim = opt.out_dim
-	training_data_size = opt.data_size
-	final_net = StackDAE(in_dim, end_dim, stack_num)
+def train_dae_layer(model, train_loader, val_loader, device, noise_fn, opt, layer):
+    """Train a single DAE layer with validation, early stopping, and logging.
 
-	# Compute geometric stride to match StackDAE's layer sizing
-	stride = pow(in_dim / end_dim, 1 / stack_num)
+    Args:
+        model: DAE model
+        train_loader: training data loader
+        val_loader: validation data loader (can be None)
+        device: torch device
+        noise_fn: callable noise function
+        opt: parsed arguments
+        layer: current layer number (1-indexed)
 
-	# Set Data Loader(input pipeline)
-	Test_dataset = StateData(data_size=training_data_size)
-	train_loader_raw = torch.utils.data.DataLoader(Test_dataset, batch_size=opt.batchSize,
-												shuffle=True)#, num_workers=4, pin_memory=True
-	
-	
-	out_dim = in_dim / stride
-	stacked_enc_net = nn.Sequential()
-	stacked_dec_net = nn.Sequential()
-	for i in range(stack_num):
-		model=DAE(int(in_dim), int(out_dim)).to(device)
+    Returns:
+        Tensor: last training output
+    """
+    loss_fn = nn.MSELoss()
+    optimizer = optim.Adam(model.parameters(), lr=opt.lr, betas=(0.5, 0.999))
 
-		if i==0:
-			model.train_DAE(train_loader_raw,device, learning_rate=opt.lr, epoch=opt.epoch, noise_r=opt.noise_r, layer=i+1)
-		else:
-			model.train_DAE(train_loader,device, learning_rate=opt.lr, epoch=opt.epoch, noise_r=opt.noise_r, layer=i+1)
+    # Learning rate scheduler with optional warmup
+    if opt.warmup_epochs > 0:
+        def lr_lambda(epoch):
+            if epoch < opt.warmup_epochs:
+                return (epoch + 1) / opt.warmup_epochs
+            return 0.2 ** ((epoch - opt.warmup_epochs) // 6)
+        scheduler = optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
+    else:
+        scheduler = optim.lr_scheduler.StepLR(optimizer, step_size=6, gamma=0.2)
 
-		stacked_enc_net.add_module("encoder_%d" % i, model.encoder)
-		stacked_dec_net.add_module("decoder_%d" % i, model.decoder)
+    # Early stopping state
+    best_val_loss = float('inf')
+    patience_counter = 0
+    best_state = None
 
-		Test_dataset = clean_output(train_loader_raw, stacked_enc_net, device)
-		train_loader = torch.utils.data.DataLoader(Test_dataset, batch_size=opt.batchSize,
-												shuffle=True)
-		
-		in_dim /= stride
-		out_dim = in_dim / stride
+    for ep in range(opt.epoch):
+        # --- Training ---
+        model.train()
+        train_loss = 0.0
+        train_batches = 0
 
-	stacked_enc_dict = stacked_enc_net.state_dict()
-	stacked_dec_dict = stacked_dec_net.state_dict()
-	new_enc_dict = OrderedDict()
-	new_dec_dict = OrderedDict()
+        for i, data in enumerate(train_loader):
+            data = data.to(device)
+            noise_data = noise_fn(data, float(opt.noise_r) / 100)
+            noise_data = noise_data.to(device)
 
-	for k, v in stacked_enc_dict.items():
-		name = 'stack_enc.' + k # add `stack_enc.` to encoder model dict
-		new_enc_dict[name] = v
+            optimizer.zero_grad()
+            output = model(noise_data)
+            error = loss_fn(output, data)
+            error.backward()
+            optimizer.step()
 
-	# Reverse decoder layers: decoder_0 becomes the last in stack_dec, etc.
-	# Remap keys: decoder_i trained standalone -> decoder_(N-1-i) in StackDAE
-	dec_items = list(stacked_dec_dict.items())
-	for k, v in dec_items:
-		name = 'stack_dec.' + k
-		new_dec_dict[name] = v
+            train_loss += error.item()
+            train_batches += 1
 
-	new_enc_dict.update(new_dec_dict)
-	new_state_dict = new_enc_dict
+        avg_train_loss = train_loss / max(train_batches, 1)
+        scheduler.step()
 
-	final_net.load_state_dict(new_state_dict)
+        # --- Validation ---
+        avg_val_loss = None
+        if val_loader is not None:
+            model.eval()
+            val_loss = 0.0
+            val_batches = 0
+            with torch.no_grad():
+                for data in val_loader:
+                    data = data.to(device)
+                    noise_data = noise_fn(data, float(opt.noise_r) / 100)
+                    noise_data = noise_data.to(device)
+                    output = model(noise_data)
+                    error = loss_fn(output, data)
+                    val_loss += error.item()
+                    val_batches += 1
+            avg_val_loss = val_loss / max(val_batches, 1)
 
-	# Save trained model in 'model' folder
-	chekp = {'in_dim': opt.in_dim,
-			 'out_dim': opt.out_dim,
-			 'stack_num': opt.stack_num,
-			 'model': final_net.state_dict()}
-	torch.save(chekp, 'model/chekp.pt')
-	print('\nmodel stored!\n')
+        # --- Logging ---
+        lr = optimizer.param_groups[0]['lr']
+        if avg_val_loss is not None:
+            logger.info(
+                'Layer %d | Epoch %d/%d | Train Loss: %.6f | Val Loss: %.6f | LR: %.6f',
+                layer, ep + 1, opt.epoch, avg_train_loss, avg_val_loss, lr)
+        else:
+            logger.info(
+                'Layer %d | Epoch %d/%d | Train Loss: %.6f | LR: %.6f',
+                layer, ep + 1, opt.epoch, avg_train_loss, lr)
 
-	
+        # --- TensorBoard ---
+        if opt.writer is not None:
+            global_step = ep + (layer - 1) * opt.epoch
+            opt.writer.add_scalar(f'layer_{layer}/train_loss', avg_train_loss, ep)
+            opt.writer.add_scalar(f'layer_{layer}/learning_rate', lr, ep)
+            if avg_val_loss is not None:
+                opt.writer.add_scalar(f'layer_{layer}/val_loss', avg_val_loss, ep)
+
+        # --- Early stopping ---
+        if opt.patience > 0 and avg_val_loss is not None:
+            if avg_val_loss < best_val_loss - opt.min_delta:
+                best_val_loss = avg_val_loss
+                patience_counter = 0
+                best_state = model.state_dict().copy()
+            else:
+                patience_counter += 1
+                if patience_counter >= opt.patience:
+                    logger.info('Layer %d | Early stopping at epoch %d (patience=%d)',
+                                layer, ep + 1, opt.patience)
+                    if best_state is not None:
+                        model.load_state_dict(best_state)
+                    break
+
+    return output
+
+
+def train(opt):
+    """Train a Stacked DAE with layer-wise pretraining.
+
+    Args:
+        opt: parsed command-line arguments
+    """
+    device = select_device()
+    stack_num = opt.stack_num
+    in_dim = opt.in_dim
+    end_dim = opt.out_dim
+
+    final_net = StackDAE(in_dim, end_dim, stack_num)
+
+    # Compute geometric stride to match StackDAE's layer sizing
+    stride = pow(in_dim / end_dim, 1 / stack_num)
+
+    # Get noise function
+    noise_fn = get_noise_fn(opt.noise_type)
+    logger.info('Using noise type: %s (ratio: %d%%)', opt.noise_type, opt.noise_r)
+
+    # Set up TensorBoard writer
+    opt.writer = None
+    if opt.tensorboard:
+        log_dir = opt.log_dir or 'runs/sdae_training'
+        opt.writer = SummaryWriter(log_dir=log_dir)
+        logger.info('TensorBoard logging to: %s', log_dir)
+
+    # Load full dataset
+    full_dataset = StateData(data_size=opt.data_size)
+
+    # Train/val split
+    if opt.val_ratio > 0:
+        train_dataset, val_dataset = split_dataset(full_dataset, opt.val_ratio)
+        logger.info('Dataset: %d train, %d validation', len(train_dataset), len(val_dataset))
+    else:
+        train_dataset = full_dataset
+        val_dataset = None
+        logger.info('Dataset: %d train (no validation)', len(train_dataset))
+
+    train_loader_raw = torch.utils.data.DataLoader(
+        train_dataset, batch_size=opt.batchSize, shuffle=True)
+    val_loader_raw = None
+    if val_dataset is not None:
+        val_loader_raw = torch.utils.data.DataLoader(
+            val_dataset, batch_size=opt.batchSize, shuffle=False)
+
+    # Layer-wise pretraining
+    cur_in_dim = in_dim
+    out_dim = in_dim / stride
+    stacked_enc_net = nn.Sequential()
+    stacked_dec_net = nn.Sequential()
+    train_loader = train_loader_raw
+    val_loader = val_loader_raw
+
+    for i in range(stack_num):
+        logger.info('--- Training layer %d/%d (dim: %d -> %d) ---',
+                     i + 1, stack_num, int(cur_in_dim), int(out_dim))
+
+        model = DAE(int(cur_in_dim), int(out_dim)).to(device)
+
+        train_dae_layer(model, train_loader, val_loader,
+                        device, noise_fn, opt, layer=i + 1)
+
+        stacked_enc_net.add_module("encoder_%d" % i, model.encoder)
+        stacked_dec_net.add_module("decoder_%d" % i, model.decoder)
+
+        # Generate clean outputs for next layer
+        train_enc_dataset = clean_output(train_loader_raw, stacked_enc_net, device)
+        train_loader = torch.utils.data.DataLoader(
+            train_enc_dataset, batch_size=opt.batchSize, shuffle=True)
+
+        val_loader = None
+        if val_loader_raw is not None:
+            val_enc_dataset = clean_output(val_loader_raw, stacked_enc_net, device)
+            val_loader = torch.utils.data.DataLoader(
+                val_enc_dataset, batch_size=opt.batchSize, shuffle=False)
+
+        cur_in_dim /= stride
+        out_dim = cur_in_dim / stride
+
+    # Assemble final stacked model
+    stacked_enc_dict = stacked_enc_net.state_dict()
+    stacked_dec_dict = stacked_dec_net.state_dict()
+    new_state_dict = OrderedDict()
+
+    for k, v in stacked_enc_dict.items():
+        new_state_dict['stack_enc.' + k] = v
+    for k, v in stacked_dec_dict.items():
+        new_state_dict['stack_dec.' + k] = v
+
+    final_net.load_state_dict(new_state_dict)
+
+    # Evaluate final reconstruction loss
+    final_net.to(device).eval()
+    loss_fn = nn.MSELoss()
+    total_loss = 0.0
+    total_batches = 0
+    with torch.no_grad():
+        loader = val_loader_raw if val_loader_raw is not None else train_loader_raw
+        for data in loader:
+            data = data.to(device)
+            output = final_net(data)
+            total_loss += loss_fn(output, data).item()
+            total_batches += 1
+    final_loss = total_loss / max(total_batches, 1)
+    logger.info('Final reconstruction loss: %.6f', final_loss)
+
+    if opt.writer is not None:
+        opt.writer.add_scalar('final/reconstruction_loss', final_loss, 0)
+
+    # Save model
+    os.makedirs('model', exist_ok=True)
+    checkpoint = {
+        'in_dim': opt.in_dim,
+        'out_dim': opt.out_dim,
+        'stack_num': opt.stack_num,
+        'noise_type': opt.noise_type,
+        'noise_r': opt.noise_r,
+        'model': final_net.state_dict(),
+        'final_loss': final_loss,
+    }
+    save_path = opt.save_path or 'model/chekp.pt'
+    torch.save(checkpoint, save_path)
+    logger.info('Model saved to %s', save_path)
+
+    if opt.writer is not None:
+        opt.writer.close()
+
 
 if __name__ == '__main__':
-	parser = argparse.ArgumentParser()
-	parser.add_argument('--epoch', type=int, default=15, help='number of training epochs')
-	parser.add_argument('--data_size', type=int, default=200000, help='size of training data')
-	parser.add_argument('--lr', type=float, default=0.0002, help='learning rate, default=0.0002')
-	parser.add_argument('--workers', type=int, help='number of data loading workers', default=8)
-	parser.add_argument('--batchSize', type=int, default=640, help='input batch size')
-	parser.add_argument('--in_dim', type=int, default=48, help='input dimension')
-	parser.add_argument('--out_dim', type=int, default=3, help='output(feature) dimension')
-	parser.add_argument('--stack_num', type=int, default=4, help='number of hidden layers')
-	parser.add_argument('--noise_r', type=int, default=10, help='Ratio of noise')
+    parser = argparse.ArgumentParser(description='Train Stacked Denoising Autoencoder')
 
-	opt = parser.parse_args()
+    # Data
+    parser.add_argument('--data_size', type=int, default=200000, help='size of training data')
+    parser.add_argument('--val_ratio', type=float, default=0.1,
+                        help='validation split ratio (0 to disable)')
 
-	train()
+    # Model
+    parser.add_argument('--in_dim', type=int, default=48, help='input dimension')
+    parser.add_argument('--out_dim', type=int, default=3, help='output (feature) dimension')
+    parser.add_argument('--stack_num', type=int, default=4, help='number of encoder/decoder layers')
+
+    # Training
+    parser.add_argument('--epoch', type=int, default=15, help='training epochs per layer')
+    parser.add_argument('--lr', type=float, default=0.0002, help='learning rate')
+    parser.add_argument('--batchSize', type=int, default=640, help='batch size')
+    parser.add_argument('--workers', type=int, default=8, help='data loading workers')
+    parser.add_argument('--warmup_epochs', type=int, default=0,
+                        help='linear warmup epochs (0 to disable)')
+
+    # Noise
+    parser.add_argument('--noise_type', type=str, default='salt_and_pepper',
+                        choices=['salt_and_pepper', 'gaussian', 'masking'],
+                        help='noise type for denoising')
+    parser.add_argument('--noise_r', type=int, default=10, help='noise ratio (percent)')
+
+    # Early stopping
+    parser.add_argument('--patience', type=int, default=0,
+                        help='early stopping patience (0 to disable)')
+    parser.add_argument('--min_delta', type=float, default=1e-4,
+                        help='minimum improvement for early stopping')
+
+    # Logging
+    parser.add_argument('--tensorboard', action='store_true',
+                        help='enable TensorBoard logging')
+    parser.add_argument('--log_dir', type=str, default=None,
+                        help='TensorBoard log directory')
+
+    # Output
+    parser.add_argument('--save_path', type=str, default=None,
+                        help='model save path (default: model/chekp.pt)')
+
+    opt = parser.parse_args()
+    train(opt)

--- a/utils.py
+++ b/utils.py
@@ -1,66 +1,104 @@
-import numpy as np
+"""Data loading and utility functions."""
 import random
-import torch
 import pickle
+import torch
 from torch.utils.data import Dataset
 
 
-# Fetch Data
 class StateData(Dataset):
-	'''Dataset setting and preprocessing'''
+    """Dataset for observation state vectors.
 
-	def __init__(self, data=None, data_size=100000):
-		self.observation = data
-		if not self.observation:
-			with open('dataset/observation.data', 'rb') as f:
-				self.observation = pickle.load(f, encoding='bytes')
-				self.observation = random.sample(self.observation, data_size)
-			#self.observation = torch.load('dataset/observation_clusterd.pt')[320000:330000]
+    Loads data from a pickle file or accepts pre-loaded data.
+    Normalizes each sample to [0, 1] range.
 
-	def __len__(self):
-		return len(self.observation)
-	def __getitem__(self, idx):
-        # normalize 0-1
-		max_ob = self.observation[idx].max()
-		min_ob = self.observation[idx].min()
-		state = (self.observation[idx] - min_ob) / (max_ob - min_ob + 1e-8)
-        # np.array to tensor
-		state = torch.from_numpy(state).float()
-		return state
+    Args:
+        data (list, optional): pre-loaded list of numpy arrays
+        data_size (int): number of samples to use
+        data_path (str): path to pickle file (used if data is None)
+    """
+
+    def __init__(self, data=None, data_size=100000, data_path='dataset/observation.data'):
+        self.observation = data
+        if self.observation is None:
+            with open(data_path, 'rb') as f:
+                self.observation = pickle.load(f, encoding='bytes')
+                self.observation = random.sample(self.observation, data_size)
+
+    def __len__(self):
+        return len(self.observation)
+
+    def __getitem__(self, idx):
+        sample = self.observation[idx]
+        max_val = sample.max()
+        min_val = sample.min()
+        # Normalize to [0, 1] with epsilon for constant inputs
+        state = (sample - min_val) / (max_val - min_val + 1e-8)
+        state = torch.from_numpy(state).float()
+        return state
 
 
 def select_device(force_cpu=False):
-	'''Choose training/visualization/extraction device based on CUDA availability'''
-	cuda = False if force_cpu else torch.cuda.is_available()
-	device = torch.device('cuda:0' if cuda else 'cpu')
+    """Select training device (CPU or CUDA).
 
-	if not cuda:
-		print('Using CPU')
-	if cuda:
-		c = 1024 ** 2  # bytes to MB
-		ng = torch.cuda.device_count()
-		x = [torch.cuda.get_device_properties(i) for i in range(ng)]
-		print("Using CUDA device0 _CudaDeviceProperties(name='%s', total_memory=%dMB)" %
-			(x[0].name, x[0].total_memory / c))
-		if ng > 0:
-			# torch.cuda.set_device(0)  # OPTIONAL: Set GPU ID
-			for i in range(1, ng):
-				print("           device%g _CudaDeviceProperties(name='%s', total_memory=%dMB)" %
- 						(i, x[i].name, x[i].total_memory / c))
+    Args:
+        force_cpu (bool): force CPU even if CUDA is available
 
-	print('')  # skip a line
-	return device
+    Returns:
+        torch.device: selected device
+    """
+    cuda = False if force_cpu else torch.cuda.is_available()
+    device = torch.device('cuda:0' if cuda else 'cpu')
+
+    if not cuda:
+        print('Using CPU')
+    if cuda:
+        c = 1024 ** 2
+        ng = torch.cuda.device_count()
+        x = [torch.cuda.get_device_properties(i) for i in range(ng)]
+        print("Using CUDA device0 _CudaDeviceProperties(name='%s', total_memory=%dMB)" %
+              (x[0].name, x[0].total_memory / c))
+        for i in range(1, ng):
+            print("           device%g _CudaDeviceProperties(name='%s', total_memory=%dMB)" %
+                  (i, x[i].name, x[i].total_memory / c))
+    print('')
+    return device
+
 
 def clean_output(train_loader, stacked_net, device):
-	'''Feed clean data into previously trained excoder to generate clean output. Use these outputs
-	to construct a new dataset for training the next autoencoder.'''
-	output_stack = []
-	for i, data in enumerate(train_loader):
-		data = data.to(device)
-		output=stacked_net(data).detach().cpu().numpy()
-		for j in range(output.shape[0]):
-			output_stack.append(output[j])
-	Test_dataset = StateData(output_stack)
-	
-	return Test_dataset
+    """Generate clean encoder outputs for training next layer.
 
+    Passes data through the current encoder stack and collects outputs
+    to form a new dataset for the next autoencoder layer.
+
+    Args:
+        train_loader: DataLoader with input data
+        stacked_net: current encoder stack (nn.Sequential)
+        device: torch device
+
+    Returns:
+        StateData: dataset of encoder outputs
+    """
+    output_stack = []
+    with torch.no_grad():
+        for data in train_loader:
+            data = data.to(device)
+            output = stacked_net(data).cpu().numpy()
+            for j in range(output.shape[0]):
+                output_stack.append(output[j])
+    return StateData(output_stack)
+
+
+def split_dataset(dataset, val_ratio=0.1):
+    """Split a dataset into train and validation sets.
+
+    Args:
+        dataset: a torch Dataset
+        val_ratio (float): fraction of data for validation (0.0 to 1.0)
+
+    Returns:
+        tuple: (train_dataset, val_dataset)
+    """
+    total = len(dataset)
+    val_size = int(total * val_ratio)
+    train_size = total - val_size
+    return torch.utils.data.random_split(dataset, [train_size, val_size])

--- a/visualize.py
+++ b/visualize.py
@@ -1,91 +1,100 @@
-from model import StackDAE
-import utils
-import torch
-import numpy as np
+"""Visualization of SDAE features and reconstructions."""
+import os
 import argparse
+import torch
 import matplotlib
+matplotlib.use('Agg')  # non-interactive backend
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
 
+from model import StackDAE
+import utils
 
-def visualize(data_size = 10000):
-	'''
-	Plot 3-dimensional feature space and reconstructed result. 
-	Images are stored in 'result_SDAE'
-	* Have to used autoencoder models with 3-dimensional output
-	 Can only be used on training data *
 
-	'''
-	batchSize = 100
-	device = utils.select_device()
-	Test_dataset = utils.StateData(data_size=data_size)
-	visu_loader = torch.utils.data.DataLoader(Test_dataset, batch_size=batchSize, shuffle=True)
-	
-	chekp = torch.load('model/chekp.pt')
-	reconstruct_dim = chekp['in_dim']
-	feature_dim = chekp['out_dim']
-	chekp_model = chekp['model']
-	stack_num = chekp['stack_num']
-	
-	model = StackDAE(reconstruct_dim, feature_dim, stack_num)
+def visualize(data_size=10000, model_path='model/chekp.pt', output_dir='result_SDAE'):
+    """Plot 3D feature space and reconstructed results.
 
-	model.to(device).load_state_dict(chekp_model)
-	model.eval()
+    Args:
+        data_size (int): number of data points to visualize
+        model_path (str): path to trained model checkpoint
+        output_dir (str): directory to save result images
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    batchSize = 100
+    device = utils.select_device()
+    dataset = utils.StateData(data_size=data_size)
+    visu_loader = torch.utils.data.DataLoader(dataset, batch_size=batchSize, shuffle=True)
 
-	reconstruct_stack = []
-	feature_stack = []
-	with torch.no_grad():
-		for i, data in enumerate(visu_loader):
-			data = data.to(device)
-			reconstruct = model.forward(data)
-			reconstruct_stack.append(reconstruct.cpu())
-			feature_stack.append(model.hidden_feature.cpu())
+    checkpoint = torch.load(model_path, map_location=device, weights_only=False)
+    reconstruct_dim = checkpoint['in_dim']
+    feature_dim = checkpoint['out_dim']
+    stack_num = checkpoint['stack_num']
 
-	reconstruct_stack = torch.cat(reconstruct_stack).numpy()
-	feature_stack = torch.cat(feature_stack).numpy()
+    model = StackDAE(reconstruct_dim, feature_dim, stack_num)
+    model.to(device).load_state_dict(checkpoint['model'])
+    model.eval()
 
-	print('%d data points, input size: %d, feature size: %d' % (feature_stack.shape[0], reconstruct_dim, feature_stack.shape[1]))
+    reconstruct_stack = []
+    feature_stack = []
+    with torch.no_grad():
+        for data in visu_loader:
+            data = data.to(device)
+            reconstruct = model(data)
+            reconstruct_stack.append(reconstruct.cpu())
+            feature_stack.append(model.hidden_feature.cpu())
 
-	fig1 = plt.figure()
-	ax = Axes3D(fig1)
-	ax.scatter(feature_stack[:,0], feature_stack[:,1], feature_stack[:,2])
-	fig1.savefig('result_SDAE/result_feature.png')
+    reconstruct_stack = torch.cat(reconstruct_stack).numpy()
+    feature_stack = torch.cat(feature_stack).numpy()
 
-	fig2 = plt.figure()
-	ax = Axes3D(fig2)
-	ax.scatter(reconstruct_stack[:,-8], reconstruct_stack[:,-7], reconstruct_stack[:,-6])
-	fig2.savefig('result_SDAE/result_reconstruct.png')
+    print('%d data points, input size: %d, feature size: %d' %
+          (feature_stack.shape[0], reconstruct_dim, feature_stack.shape[1]))
 
-	return feature_stack
+    fig1 = plt.figure()
+    ax = Axes3D(fig1)
+    ax.scatter(feature_stack[:, 0], feature_stack[:, 1], feature_stack[:, 2])
+    fig1.savefig(os.path.join(output_dir, 'result_feature.png'))
+    plt.close(fig1)
 
-def visualize_orig(data_size = 10000):
-	'''
-	Plot positions(x, y, z) of the last joint of original data(observation). 
-	* Can only be used on training data *
+    fig2 = plt.figure()
+    ax = Axes3D(fig2)
+    ax.scatter(reconstruct_stack[:, -8], reconstruct_stack[:, -7], reconstruct_stack[:, -6])
+    fig2.savefig(os.path.join(output_dir, 'result_reconstruct.png'))
+    plt.close(fig2)
 
-	'''
-	batchSize = 100
-	device = utils.select_device()
-	Test_dataset = utils.StateData(data_size)
-	visu_loader = torch.utils.data.DataLoader(Test_dataset, batch_size=batchSize, shuffle=True)
+    return feature_stack
 
-	output_stack = torch.FloatTensor(48).unsqueeze(0)
 
-	for i, data in enumerate(visu_loader):
-		output_stack = torch.cat((output_stack, data))
+def visualize_orig(data_size=10000, output_dir='result_SDAE'):
+    """Plot positions of the last joint from original observation data.
 
-	output_stack = output_stack[1:].numpy()
-	fig = plt.figure()
+    Args:
+        data_size (int): number of data points
+        output_dir (str): directory to save result images
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    batchSize = 100
+    dataset = utils.StateData(data_size)
+    visu_loader = torch.utils.data.DataLoader(dataset, batch_size=batchSize, shuffle=True)
 
-	ax = Axes3D(fig)
-	ax.scatter(output_stack[:,-8],output_stack[:,-7],output_stack[:,-6])
-	fig.savefig('result_SDAE/result_orig.png')
+    output_stack = []
+    for data in visu_loader:
+        output_stack.append(data)
 
-	
+    output_stack = torch.cat(output_stack).numpy()
+    fig = plt.figure()
+    ax = Axes3D(fig)
+    ax.scatter(output_stack[:, -8], output_stack[:, -7], output_stack[:, -6])
+    fig.savefig(os.path.join(output_dir, 'result_orig.png'))
+    plt.close(fig)
+
 
 if __name__ == '__main__':
-	parser = argparse.ArgumentParser()
-	parser.add_argument('--data_size', type=int, default=10000, help='size of data used for visualization')
-
-	opt = parser.parse_args()
-	visualize(opt.data_size)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--data_size', type=int, default=10000,
+                        help='size of data used for visualization')
+    parser.add_argument('--model_path', type=str, default='model/chekp.pt',
+                        help='path to trained model')
+    parser.add_argument('--output_dir', type=str, default='result_SDAE',
+                        help='output directory for plots')
+    opt = parser.parse_args()
+    visualize(opt.data_size, opt.model_path, opt.output_dir)


### PR DESCRIPTION
## New Features

### Train/Validation Split
`--val_ratio 0.1` splits data for proper evaluation. Validation loss reported per epoch per layer. Set to 0 to disable.

### Early Stopping
`--patience 5` stops training a layer if validation loss doesn't improve for N epochs. Restores best weights automatically. `--min_delta` controls minimum improvement threshold.

### Learning Rate Warmup
`--warmup_epochs 3` linearly ramps LR from 0 to target over N epochs before applying step decay.

### Configurable Noise Types
`--noise_type` now supports:
- `salt_and_pepper` (default) — random min/max corruption
- `gaussian` — additive Gaussian noise scaled by data range
- `masking` — random zero-out

All noise functions extracted to `noise.py` with clean registry pattern.

### TensorBoard Logging
`--tensorboard` enables loss and LR logging per layer. View with `tensorboard --logdir runs/`.

### Final Evaluation
After all layers trained, reports reconstruction loss on validation set (or train set if no val split).

## Code Quality
- Training logic removed from `model.py` — models are now pure architecture
- Proper `logging` module instead of `print()`
- `torch.no_grad()` in inference paths
- `weights_only` param for `torch.load`
- 31 passing tests (model + noise + utils)

## Example
```bash
python train.py --noise_type gaussian --val_ratio 0.1 --patience 5 --warmup_epochs 3 --tensorboard
```