### PR TITLE
fix: address Claude Code review findings (6 bugs + 1 perf)

### DIFF
--- a/extract.py
+++ b/extract.py
@@ -20,7 +20,8 @@ class Autoencoder(object):
         stack_num = checkpoint['stack_num']
 
         self.model = StackDAE(self.reconstruct_dim, feature_dim, stack_num)
-        self.model.to(self.device).load_state_dict(checkpoint['model'])
+        self.model.load_state_dict(checkpoint['model'])
+        self.model.to(self.device)
         self.model.eval()
 
     def extract(self, data):

--- a/model.py
+++ b/model.py
@@ -12,7 +12,7 @@ class DAE(nn.Module):
     """
 
     def __init__(self, in_dim, out_dim):
-        super(DAE, self).__init__()
+        super().__init__()
         self.in_dim = int(in_dim)
         self.out_dim = int(out_dim)
         self.encoder = nn.Sequential(
@@ -20,11 +20,13 @@ class DAE(nn.Module):
             nn.LeakyReLU())
         self.decoder = nn.Linear(self.out_dim, self.in_dim)
 
-    def forward(self, input):
-        size = input.size()
-        self.hidden_output = self.encoder(input)
-        output = self.decoder(self.hidden_output)
-        return output.view(size)
+    def forward(self, x):
+        hidden = self.encoder(x)
+        return self.decoder(hidden)
+
+    def encode(self, x):
+        """Encode input to hidden representation."""
+        return self.encoder(x)
 
 
 class StackDAE(nn.Module):
@@ -40,36 +42,49 @@ class StackDAE(nn.Module):
     """
 
     def __init__(self, in_dim, out_dim, layer_num):
-        super(StackDAE, self).__init__()
+        super().__init__()
 
-        stride = pow(in_dim / out_dim, 1 / layer_num)
+        # Pre-compute all layer dimensions to avoid float drift
+        dims = self._compute_dims(in_dim, out_dim, layer_num)
 
         self.stack_enc = nn.Sequential()
         self.stack_dec = nn.Sequential()
 
-        cur_dim = in_dim
         # Build stacked encoder
         for i in range(layer_num):
-            next_dim = cur_dim / stride
             self.stack_enc.add_module(
                 'encoder_%d' % i,
-                nn.Sequential(nn.Linear(int(cur_dim), int(next_dim)), nn.LeakyReLU()))
-            cur_dim = next_dim
+                nn.Sequential(nn.Linear(dims[i], dims[i + 1]), nn.LeakyReLU()))
 
         # Build stacked decoder (reverse order)
         for i in range(layer_num):
-            next_dim = cur_dim * stride
+            dec_idx = layer_num - i
             self.stack_dec.add_module(
                 'decoder_%d' % (layer_num - i - 1),
-                nn.Linear(int(cur_dim), int(next_dim)))
-            cur_dim = next_dim
+                nn.Linear(dims[dec_idx], dims[dec_idx - 1]))
 
-    def forward(self, input):
-        self.hidden_feature = self.stack_enc(input)
-        output = self.stack_dec(self.hidden_feature)
-        return output
+    @staticmethod
+    def _compute_dims(in_dim, out_dim, layer_num):
+        """Pre-compute integer dimensions for each layer to avoid float drift.
 
-    def extract(self, input):
+        Returns:
+            list[int]: dimensions from input to bottleneck (length = layer_num + 1)
+        """
+        stride = pow(in_dim / out_dim, 1 / layer_num)
+        dims = [in_dim]
+        cur = in_dim
+        for i in range(layer_num - 1):
+            cur = cur / stride
+            dims.append(int(round(cur)))
+        dims.append(int(round(out_dim)))  # Force exact target dim at bottleneck
+        return dims
+
+    def forward(self, x):
+        """Forward pass returning (reconstruction, features) tuple."""
+        features = self.stack_enc(x)
+        reconstruction = self.stack_dec(features)
+        return reconstruction, features
+
+    def extract(self, x):
         """Extract bottleneck features without decoding."""
-        feature = self.stack_enc(input)
-        return feature
+        return self.stack_enc(x)

--- a/noise.py
+++ b/noise.py
@@ -1,5 +1,4 @@
 """Noise functions for denoising autoencoders."""
-import numpy as np
 import torch
 
 
@@ -13,17 +12,12 @@ def salt_and_pepper(X, prop):
     Returns:
         Tensor: corrupted copy of X
     """
-    X_clone = X.clone().view(-1, 1)
-    num_feature = X_clone.size(0)
-    mn = X_clone.min()
-    mx = X_clone.max()
-    indices = np.random.randint(0, num_feature, int(num_feature * prop))
-    for elem in indices:
-        if np.random.random() < 0.5:
-            X_clone[elem] = mn
-        else:
-            X_clone[elem] = mx
-    return X_clone.view(X.size())
+    X_clone = X.clone()
+    mask = torch.rand_like(X) < prop
+    salt = torch.rand_like(X) < 0.5
+    X_clone[mask & salt] = X.min()
+    X_clone[mask & ~salt] = X.max()
+    return X_clone
 
 
 def gaussian(X, prop):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,4 @@
 """Tests for SDAE model components."""
-import numpy as np
 import torch
 import torch.nn as nn
 
@@ -18,11 +17,10 @@ class TestDAE:
         x = torch.randn(16, 48)
         assert model(x).shape == (16, 48)
 
-    def test_hidden_output_shape(self):
+    def test_encode_shape(self):
         model = DAE(48, 24)
         x = torch.randn(16, 48)
-        _ = model(x)
-        assert model.hidden_output.shape == (16, 24)
+        assert model.encode(x).shape == (16, 24)
 
     def test_gradient_flows(self):
         model = DAE(48, 24)
@@ -35,34 +33,64 @@ class TestDAE:
 
 class TestStackDAE:
 
-    def test_forward_shape(self):
+    def test_forward_returns_tuple(self):
         model = StackDAE(48, 3, 4)
         x = torch.randn(16, 48)
-        assert model(x).shape == (16, 48)
+        result = model(x)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        reconstruction, features = result
+        assert reconstruction.shape == (16, 48)
+        assert features.shape == (16, 3)
 
     def test_extract_shape(self):
         model = StackDAE(48, 3, 4)
         x = torch.randn(16, 48)
         assert model.extract(x).shape == (16, 3)
 
+    def test_compute_dims(self):
+        dims = StackDAE._compute_dims(48, 3, 4)
+        assert len(dims) == 5
+        assert dims[0] == 48
+        assert dims[-1] == 3
+        # All dims should be decreasing
+        for i in range(len(dims) - 1):
+            assert dims[i] > dims[i + 1]
+
     def test_different_layer_counts(self):
         for layers in [1, 2, 3, 5]:
             model = StackDAE(48, 3, layers)
             x = torch.randn(4, 48)
-            assert model(x).shape == (4, 48)
-            assert model.extract(x).shape[0] == 4
+            reconstruction, features = model(x)
+            assert reconstruction.shape == (4, 48)
+            assert features.shape[0] == 4
+
+    def test_exact_bottleneck_dim(self):
+        """Bottleneck should match out_dim exactly (no float drift)."""
+        model = StackDAE(48, 3, 4)
+        x = torch.randn(4, 48)
+        _, features = model(x)
+        assert features.shape == (4, 3)
+
+        model2 = StackDAE(100, 10, 5)
+        _, features2 = model2(torch.randn(4, 100))
+        assert features2.shape == (4, 10)
 
     def test_eval_deterministic(self):
         model = StackDAE(48, 3, 4)
         model.eval()
         x = torch.randn(4, 48)
         with torch.no_grad():
-            assert torch.allclose(model(x), model(x))
+            r1, f1 = model(x)
+            r2, f2 = model(x)
+        assert torch.allclose(r1, r2)
+        assert torch.allclose(f1, f2)
 
     def test_gradient_flows(self):
         model = StackDAE(48, 3, 4)
         x = torch.randn(8, 48)
-        loss = nn.MSELoss()(model(x), x)
+        reconstruction, _ = model(x)
+        loss = nn.MSELoss()(reconstruction, x)
         loss.backward()
         for name, param in model.named_parameters():
             assert param.grad is not None, f"No gradient for {name}"

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -1,6 +1,5 @@
 """Tests for noise functions."""
 import torch
-import numpy as np
 
 from noise import salt_and_pepper, gaussian, masking, get_noise_fn, NOISE_FUNCTIONS
 
@@ -17,7 +16,6 @@ class TestSaltAndPepper:
 
     def test_noise_modifies_values(self):
         torch.manual_seed(42)
-        np.random.seed(42)
         x = torch.randn(100, 48)
         assert not torch.allclose(salt_and_pepper(x, 0.5), x)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,6 +39,13 @@ class TestStateData:
         item = StateData(data=data, data_size=5)[0]
         assert torch.isfinite(item).all()
 
+    def test_normalize_false(self):
+        """When normalize=False, data should pass through as-is."""
+        data = [np.array([10.0, -5.0, 3.0] * 16) for _ in range(5)]
+        item = StateData(data=data, data_size=5, normalize=False)[0]
+        assert item[0].item() == 10.0
+        assert item[1].item() == -5.0
+
     def test_dataloader_integration(self):
         data = [np.random.randn(48).astype(np.float64) for _ in range(100)]
         loader = torch.utils.data.DataLoader(
@@ -66,7 +73,8 @@ class TestSplitDataset:
 
 class TestCleanOutput:
 
-    def test_output_dataset_type(self):
+    def test_output_not_renormalized(self):
+        """clean_output should return data without re-normalization."""
         data = [np.random.randn(48).astype(np.float64) for _ in range(64)]
         loader = torch.utils.data.DataLoader(
             StateData(data=data, data_size=64), batch_size=16)
@@ -74,4 +82,5 @@ class TestCleanOutput:
         encoder = model.stack_enc[:1]
         result = clean_output(loader, encoder, torch.device('cpu'))
         assert isinstance(result, StateData)
+        assert result.normalize is False
         assert len(result) == 64

--- a/train.py
+++ b/train.py
@@ -1,5 +1,6 @@
 """Training script for Stacked Denoising Autoencoder."""
 import os
+import copy
 import argparse
 import logging
 from collections import OrderedDict
@@ -49,6 +50,7 @@ def train_dae_layer(model, train_loader, val_loader, device, noise_fn, opt, laye
     best_val_loss = float('inf')
     patience_counter = 0
     best_state = None
+    output = None
 
     for ep in range(opt.epoch):
         # --- Training ---
@@ -114,7 +116,7 @@ def train_dae_layer(model, train_loader, val_loader, device, noise_fn, opt, laye
             if avg_val_loss < best_val_loss - opt.min_delta:
                 best_val_loss = avg_val_loss
                 patience_counter = 0
-                best_state = model.state_dict().copy()
+                best_state = copy.deepcopy(model.state_dict())
             else:
                 patience_counter += 1
                 if patience_counter >= opt.patience:
@@ -140,8 +142,8 @@ def train(opt):
 
     final_net = StackDAE(in_dim, end_dim, stack_num)
 
-    # Compute geometric stride to match StackDAE's layer sizing
-    stride = pow(in_dim / end_dim, 1 / stack_num)
+    # Use same dimension list as StackDAE to avoid float drift
+    dims = StackDAE._compute_dims(in_dim, end_dim, stack_num)
 
     # Get noise function
     noise_fn = get_noise_fn(opt.noise_type)
@@ -174,18 +176,18 @@ def train(opt):
             val_dataset, batch_size=opt.batchSize, shuffle=False)
 
     # Layer-wise pretraining
-    cur_in_dim = in_dim
-    out_dim = in_dim / stride
     stacked_enc_net = nn.Sequential()
     stacked_dec_net = nn.Sequential()
     train_loader = train_loader_raw
     val_loader = val_loader_raw
 
     for i in range(stack_num):
+        cur_in_dim = dims[i]
+        cur_out_dim = dims[i + 1]
         logger.info('--- Training layer %d/%d (dim: %d -> %d) ---',
-                     i + 1, stack_num, int(cur_in_dim), int(out_dim))
+                     i + 1, stack_num, cur_in_dim, cur_out_dim)
 
-        model = DAE(int(cur_in_dim), int(out_dim)).to(device)
+        model = DAE(cur_in_dim, cur_out_dim).to(device)
 
         train_dae_layer(model, train_loader, val_loader,
                         device, noise_fn, opt, layer=i + 1)
@@ -203,9 +205,6 @@ def train(opt):
             val_enc_dataset = clean_output(val_loader_raw, stacked_enc_net, device)
             val_loader = torch.utils.data.DataLoader(
                 val_enc_dataset, batch_size=opt.batchSize, shuffle=False)
-
-        cur_in_dim /= stride
-        out_dim = cur_in_dim / stride
 
     # Assemble final stacked model
     stacked_enc_dict = stacked_enc_net.state_dict()
@@ -228,8 +227,8 @@ def train(opt):
         loader = val_loader_raw if val_loader_raw is not None else train_loader_raw
         for data in loader:
             data = data.to(device)
-            output = final_net(data)
-            total_loss += loss_fn(output, data).item()
+            reconstruction, _ = final_net(data)
+            total_loss += loss_fn(reconstruction, data).item()
             total_batches += 1
     final_loss = total_loss / max(total_batches, 1)
     logger.info('Final reconstruction loss: %.6f', final_loss)

--- a/utils.py
+++ b/utils.py
@@ -9,16 +9,19 @@ class StateData(Dataset):
     """Dataset for observation state vectors.
 
     Loads data from a pickle file or accepts pre-loaded data.
-    Normalizes each sample to [0, 1] range.
+    Normalizes each sample to [0, 1] range unless normalize=False.
 
     Args:
         data (list, optional): pre-loaded list of numpy arrays
         data_size (int): number of samples to use
         data_path (str): path to pickle file (used if data is None)
+        normalize (bool): whether to normalize samples to [0, 1]
     """
 
-    def __init__(self, data=None, data_size=100000, data_path='dataset/observation.data'):
+    def __init__(self, data=None, data_size=100000, data_path='dataset/observation.data',
+                 normalize=True):
         self.observation = data
+        self.normalize = normalize
         if self.observation is None:
             with open(data_path, 'rb') as f:
                 self.observation = pickle.load(f, encoding='bytes')
@@ -29,11 +32,11 @@ class StateData(Dataset):
 
     def __getitem__(self, idx):
         sample = self.observation[idx]
-        max_val = sample.max()
-        min_val = sample.min()
-        # Normalize to [0, 1] with epsilon for constant inputs
-        state = (sample - min_val) / (max_val - min_val + 1e-8)
-        state = torch.from_numpy(state).float()
+        state = torch.from_numpy(sample).float() if not isinstance(sample, torch.Tensor) else sample.float()
+        if self.normalize:
+            max_val = state.max()
+            min_val = state.min()
+            state = (state - min_val) / (max_val - min_val + 1e-8)
         return state
 
 
@@ -49,8 +52,6 @@ def select_device(force_cpu=False):
     cuda = False if force_cpu else torch.cuda.is_available()
     device = torch.device('cuda:0' if cuda else 'cpu')
 
-    if not cuda:
-        print('Using CPU')
     if cuda:
         c = 1024 ** 2
         ng = torch.cuda.device_count()
@@ -60,6 +61,8 @@ def select_device(force_cpu=False):
         for i in range(1, ng):
             print("           device%g _CudaDeviceProperties(name='%s', total_memory=%dMB)" %
                   (i, x[i].name, x[i].total_memory / c))
+    else:
+        print('Using CPU')
     print('')
     return device
 
@@ -67,8 +70,8 @@ def select_device(force_cpu=False):
 def clean_output(train_loader, stacked_net, device):
     """Generate clean encoder outputs for training next layer.
 
-    Passes data through the current encoder stack and collects outputs
-    to form a new dataset for the next autoencoder layer.
+    Passes data through the current encoder stack and collects outputs.
+    Returns a dataset with normalize=False to avoid double normalization.
 
     Args:
         train_loader: DataLoader with input data
@@ -76,16 +79,15 @@ def clean_output(train_loader, stacked_net, device):
         device: torch device
 
     Returns:
-        StateData: dataset of encoder outputs
+        StateData: dataset of encoder outputs (not re-normalized)
     """
     output_stack = []
     with torch.no_grad():
         for data in train_loader:
             data = data.to(device)
             output = stacked_net(data).cpu().numpy()
-            for j in range(output.shape[0]):
-                output_stack.append(output[j])
-    return StateData(output_stack)
+            output_stack.extend(output)
+    return StateData(output_stack, normalize=False)
 
 
 def split_dataset(dataset, val_ratio=0.1):

--- a/visualize.py
+++ b/visualize.py
@@ -31,7 +31,8 @@ def visualize(data_size=10000, model_path='model/chekp.pt', output_dir='result_S
     stack_num = checkpoint['stack_num']
 
     model = StackDAE(reconstruct_dim, feature_dim, stack_num)
-    model.to(device).load_state_dict(checkpoint['model'])
+    model.load_state_dict(checkpoint['model'])
+    model.to(device)
     model.eval()
 
     reconstruct_stack = []
@@ -39,9 +40,9 @@ def visualize(data_size=10000, model_path='model/chekp.pt', output_dir='result_S
     with torch.no_grad():
         for data in visu_loader:
             data = data.to(device)
-            reconstruct = model(data)
-            reconstruct_stack.append(reconstruct.cpu())
-            feature_stack.append(model.hidden_feature.cpu())
+            reconstruction, features = model(data)
+            reconstruct_stack.append(reconstruction.cpu())
+            feature_stack.append(features.cpu())
 
     reconstruct_stack = torch.cat(reconstruct_stack).numpy()
     feature_stack = torch.cat(feature_stack).numpy()


### PR DESCRIPTION
Fixes from Claude Code's code review and simplification pass.

## High Priority
- **B1** `deepcopy` for early stopping state — shallow copy was corrupting saved weights
- **B6** Double normalization — `clean_output` now returns `normalize=False` datasets so encoder outputs aren't re-normalized during layer-wise training

## Medium Priority
- **B3** Separated `load_state_dict()` from `.to(device)` chaining
- **B4** Removed mutable instance attrs from forward pass — `StackDAE.forward()` returns `(reconstruction, features)` tuple
- **B5** Pre-compute integer layer dimensions via `_compute_dims()` — bottleneck now matches `out_dim` exactly regardless of layer count
- **S4** Vectorized `salt_and_pepper` — replaced numpy loop with torch tensor ops

## Tests
34 passing (added: `test_forward_returns_tuple`, `test_compute_dims`, `test_exact_bottleneck_dim`, `test_normalize_false`, `test_output_not_renormalized`, `test_encode_shape`)